### PR TITLE
Refactor configuration management with AppSettings

### DIFF
--- a/Desola.Functions.Endpoints/Functions/Airports.cs
+++ b/Desola.Functions.Endpoints/Functions/Airports.cs
@@ -5,10 +5,12 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using System.Net;
 using DesolaDomain.Interfaces;
+using DesolaDomain.Settings;
 using MediatR;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using DesolaServices.Commands.Queries;
+using Microsoft.Extensions.Options;
 
 namespace Desola.Functions.Endpoints.Functions;
 
@@ -17,13 +19,14 @@ public class Airports
     private readonly ILogger<Airports> _logger;
     private readonly IAirportRepository _airportRepository;
     private readonly IMediator _mediator;
+    private readonly AppSettings _appSettings;
 
-
-    public Airports(ILogger<Airports> logger, IAirportRepository airportRepository, IMediator mediator)
+    public Airports(ILogger<Airports> logger, IAirportRepository airportRepository, IMediator mediator, IOptions<AppSettings> settings)
     {
         _logger = logger;
         _airportRepository = airportRepository;
         _mediator = mediator;
+        _appSettings = settings.Value;
     }
 
     [Function("Airports")]

--- a/Desola.Functions.Endpoints/Program.cs
+++ b/Desola.Functions.Endpoints/Program.cs
@@ -1,21 +1,35 @@
+using DesolaDomain.Settings;
 using DesolaInfrastructure;
 using DesolaServices;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
+    .ConfigureAppConfiguration((context, config) =>
+    {
+        config.AddJsonFile("local.settings.json", optional: true, reloadOnChange: true);
+        config.AddEnvironmentVariables();
+    })
     .ConfigureServices((context, services) =>
     {
         var configuration = context.Configuration;
+
+        services.Configure<AppSettings>(configuration);
+
+        var appSettings = new AppSettings();
+        configuration.Bind(appSettings);
+        
+        services.AddSingleton(appSettings);
 
         services.AddMemoryCache();
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
 
-        services.AddDesolaInfrastructure(configuration);
-        services.AddDesolaApplications(configuration);
+        services.AddDesolaInfrastructure(appSettings);
+        services.AddDesolaApplications(appSettings);
         services.AddCors(options =>
         {
             options.AddDefaultPolicy(builder =>

--- a/DesolaDomain/Settings/AppSettings.cs
+++ b/DesolaDomain/Settings/AppSettings.cs
@@ -1,0 +1,78 @@
+﻿namespace DesolaDomain.Settings;
+
+public class AppSettings
+{
+    public string FunctionsWorkerRuntime { get; set; }
+    public string AzureWebJobsStorage { get; set; }
+    public StorageAccount StorageAccount { get; set; }
+    public BlobFiles BlobFiles { get; set; }
+    public ExternalApi ExternalApi { get; set; }
+    public Airlines Airlines { get; set; }
+    public Database Database { get; set; }
+    public AzureB2C AzureB2C { get; set; }
+}
+
+// Storage Account 
+public class StorageAccount
+{
+    public string AccountName { get; set; }
+    public string ContainerName { get; set; }
+    public string ConnectionString { get; set; }
+}
+
+// Blob File Paths
+public class BlobFiles
+{
+    public string AirportFile { get; set; }
+    public string AirportCodeFile { get; set; }
+    public string SkyScannerAirportFile { get; set; }
+    public string BlobUri { get; set; }
+    public string AirportCodeBlobUri { get; set; }
+}
+
+// External API 
+public class ExternalApi
+{
+    public AmadeusApi Amadeus { get; set; }
+    public RapidApi RapidApi { get; set; }
+}
+
+public class AmadeusApi
+{
+    public string BaseUrl { get; set; }
+    public string TokenEndpointUrl { get; set; }
+    public string ClientId { get; set; }
+    public string ClientSecret { get; set; }
+}
+
+public class RapidApi
+{
+    public string SkyScannerHost { get; set; }
+    public string SkyScannerKey { get; set; }
+    public string SkyScannerUri { get; set; }
+}
+
+// Airlines Information
+public class Airlines
+{
+    public string UnitedStatesAirlines { get; set; }
+}
+
+// Database 
+public class Database
+{
+    public string WebPageContentTableName { get; set; }
+}
+
+// Azure B2C Authentication
+public class AzureB2C
+{
+    public string Authority { get; set; }
+    public string ClientId { get; set; }
+    public string ClientSecret { get; set; }
+    public string RedirectUri { get; set; }
+    public string SignInAndSignUpPolicy { get; set; }
+    public string ApplicationIdUri { get; set; }
+    public string ApplicationScope { get; set; }
+    public string CodeVerifier { get; set; }
+}

--- a/DesolaInfrastructure/Data/AirlineRepository.cs
+++ b/DesolaInfrastructure/Data/AirlineRepository.cs
@@ -3,8 +3,9 @@ using CaptainOath.DataStore.Interface;
 using DesolaDomain.Enums;
 using DesolaDomain.Interfaces;
 using DesolaDomain.Model;
-using Microsoft.Extensions.Configuration;
+using DesolaDomain.Settings;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace DesolaInfrastructure.Data;
 
@@ -18,15 +19,16 @@ public class AirlineRepository : IAirlineRepository
     private readonly string _containerName;
     private readonly string _americanAirlines;
 
-    public AirlineRepository(IBlobStorageRepository blobStorageRepository, ICacheService cacheService, ILogger<AirlineRepository> logger, IConfiguration configuration)
+    public AirlineRepository(IBlobStorageRepository blobStorageRepository, ICacheService cacheService, ILogger<AirlineRepository> logger, IOptions<AppSettings> configuration)
     {
         _blobStorageRepository = blobStorageRepository;
         _cacheService = cacheService;
         _logger = logger;
+        var appSettings = configuration.Value;
 
-        _fileName = configuration["Airport_Code_File"] ?? throw new ArgumentNullException(nameof(configuration), "Unable to find airline file name");
-        _containerName = configuration["ContainerName"] ?? throw new ArgumentNullException(nameof(configuration), "Unable to find airline container name");
-        _americanAirlines = configuration["AmericanAirlines"] ?? throw new ArgumentNullException(nameof(configuration), "Unable to find american airlines");
+        _fileName = appSettings.BlobFiles.AirportCodeFile ?? throw new ArgumentNullException(nameof(configuration), "Unable to find airline file name");
+        _containerName = appSettings.StorageAccount.ContainerName ?? throw new ArgumentNullException(nameof(configuration), "Unable to find airline container name");
+        _americanAirlines = appSettings.Airlines.UnitedStatesAirlines?? throw new ArgumentNullException(nameof(configuration), "Unable to find american airlines");
     }
 
     public async Task<List<Airline>>  GetAllAirlinesAsync()

--- a/DesolaInfrastructure/DesolaInfrastructure.csproj
+++ b/DesolaInfrastructure/DesolaInfrastructure.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesolaInfrastructure/External/ApiService.cs
+++ b/DesolaInfrastructure/External/ApiService.cs
@@ -2,7 +2,8 @@
 using DesolaDomain.Entities.Authorization;
 using DesolaDomain.Enums;
 using DesolaDomain.Interfaces;
-using Microsoft.Extensions.Configuration;
+using DesolaDomain.Settings;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -11,14 +12,14 @@ namespace DesolaInfrastructure.External;
 public class ApiService : IApiService
 {
     private readonly IHttpService _httpService;
-    private readonly IConfiguration _configuration;
+    private readonly AppSettings _appSettings;
     private readonly ICacheService _cacheService;
     private readonly Amadeus _amadeus;
 
-    public ApiService(IHttpService httpService, IConfiguration configuration, ICacheService cacheService, Amadeus amadeus)
+    public ApiService(IHttpService httpService, IOptions<AppSettings> configuration, ICacheService cacheService, Amadeus amadeus)
     {
         _httpService = httpService;
-        _configuration = configuration;
+        _appSettings = configuration.Value;
         _cacheService = cacheService;
         _amadeus = amadeus;
     }
@@ -31,11 +32,11 @@ public class ApiService : IApiService
             return tokenData.BearerToken ?? string.Empty;
         }
 
-        var url = _configuration["Amadeus_token_endpointUrl"];
+        var url = _appSettings.ExternalApi.Amadeus.TokenEndpointUrl;
         var content = new FormUrlEncodedContent(new[]
         {
-            new KeyValuePair<string, string>("client_id", _configuration["Amadeus_client_id"] ?? throw new ArgumentNullException(nameof(_configuration),"unable to find client id")),
-            new KeyValuePair<string, string>("client_secret", _configuration["Amadeus_client_secret"] ?? throw new ArgumentNullException(nameof(_configuration),"unable to find client secret") ),
+            new KeyValuePair<string, string>("client_id", _appSettings.ExternalApi.Amadeus.ClientId ?? throw new ArgumentNullException(nameof(_appSettings),"unable to find client id")),
+            new KeyValuePair<string, string>("client_secret", _appSettings.ExternalApi.Amadeus.ClientSecret ?? throw new ArgumentNullException(nameof(_appSettings),"unable to find client secret") ),
             new KeyValuePair<string, string>("grant_type", "client_credentials")
         });
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-www-form-urlencoded");

--- a/DesolaInfrastructure/ServiceCollection.cs
+++ b/DesolaInfrastructure/ServiceCollection.cs
@@ -5,63 +5,59 @@ using CaptainOath.DataStore.Interface;
 using CaptainOath.DataStore.Repositories;
 using DesolaDomain.Entities.PageEntity;
 using DesolaDomain.Interfaces;
+using DesolaDomain.Settings;
 using DesolaInfrastructure.Data;
 using DesolaInfrastructure.External;
 using DesolaInfrastructure.Services.Implementations;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace DesolaInfrastructure
+namespace DesolaInfrastructure;
+
+public static class ServiceCollection
 {
-    public static class ServiceCollection
+    public static IServiceCollection AddDesolaInfrastructure(this IServiceCollection services, AppSettings configuration)
     {
+        services.AddSingleton<IAirportRepository, AirportRepository>();
+        services.AddSingleton<IAirlineRepository, AirlineRepository>();
+        services.AddSingleton<ICacheService, CacheService>();
 
-        public static IServiceCollection AddDesolaInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        var connectionString = configuration.BlobFiles.BlobUri;
+
+        var storageAccountConnectionString = configuration.StorageAccount.ConnectionString;
+
+        if (string.IsNullOrWhiteSpace(storageAccountConnectionString))
         {
-            services.AddSingleton<IAirportRepository, AirportRepository>();
-            services.AddSingleton<IAirlineRepository, AirlineRepository>();
-            services.AddSingleton<ICacheService, CacheService>();
-            
-            var connectionString = configuration["BlobUri"];
-
-            var storageAccountConnectionString = configuration["AzureStorageAccountConnectionString"];
-
-            if (string.IsNullOrWhiteSpace(storageAccountConnectionString))
-            {
-                throw new ArgumentNullException(nameof(storageAccountConnectionString));
-            }
-
-            services.AddBlobClientUri(connectionString);
-            services.AddBlobStorageClientUsingConnectionString(storageAccountConnectionString);
-            services.AddTableStorageClientCheck(storageAccountConnectionString);
-
-            services.AddHttpClient();
-            services.AddScoped<IHttpService, HttpService>();
-            services.AddScoped<IApiService, ApiService>();
-            services.AddScoped<IAmadeusService, AmadeusService>();
-
-            var amadeus = Amadeus
-                .builder(configuration["Amadeus_client_id"], configuration["Amadeus_client_secret"])
-                .build();
-            services.AddSingleton(amadeus);
-
-
-            return services;
+            throw new ArgumentNullException(nameof(storageAccountConnectionString));
         }
 
-        public static IServiceCollection AddTableStorageClientCheck(this IServiceCollection services, string connectionString)
-        {
-            services.AddSingleton<ITableStorageRepository<WebSection>, TableStorageRepository<WebSection>>();
+        services.AddBlobClientUri(connectionString);
+        services.AddBlobStorageClientUsingConnectionString(storageAccountConnectionString);
+        services.AddTableStorageClientCheck(storageAccountConnectionString);
 
-            services.AddSingleton(_ =>
-            {
-                var tableServiceClient = new TableServiceClient(connectionString);
-                return tableServiceClient;
-            });
+        services.AddHttpClient();
+        services.AddScoped<IHttpService, HttpService>();
+        services.AddScoped<IApiService, ApiService>();
+        services.AddScoped<IAmadeusService, AmadeusService>();
 
-            return services;
-        }
+        var amadeus = Amadeus
+            .builder(configuration.ExternalApi.Amadeus.ClientId, configuration.ExternalApi.Amadeus.ClientSecret)
+            .build();
+        services.AddSingleton(amadeus);
+
+
+        return services;
     }
 
+    public static IServiceCollection AddTableStorageClientCheck(this IServiceCollection services, string connectionString)
+    {
+        services.AddSingleton<ITableStorageRepository<WebSection>, TableStorageRepository<WebSection>>();
 
+        services.AddSingleton(_ =>
+        {
+            var tableServiceClient = new TableServiceClient(connectionString);
+            return tableServiceClient;
+        });
+
+        return services;
+    }
 }

--- a/DesolaServices/ServiceCollection.cs
+++ b/DesolaServices/ServiceCollection.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using DesolaDomain.Entities.PageEntity;
+using DesolaDomain.Settings;
 using DesolaServices.Interfaces;
 using DesolaServices.Services;
 
@@ -9,8 +9,7 @@ namespace DesolaServices;
 
 public static class ServiceCollection
 {
-    public static IServiceCollection AddDesolaApplications(this IServiceCollection services,
-        IConfiguration configuration)
+    public static IServiceCollection AddDesolaApplications(this IServiceCollection services, AppSettings appSettings)
     {
 
         services.AddScoped<IFlightSearchService, FlightSearchService>();

--- a/DesolaServices/Services/AirlineRouteService.cs
+++ b/DesolaServices/Services/AirlineRouteService.cs
@@ -2,22 +2,23 @@
 using System.Web;
 using AutoMapper;
 using DesolaDomain.Interfaces;
-using Microsoft.Extensions.Configuration;
 using DesolaDomain.Aggregates;
+using DesolaDomain.Settings;
 using DesolaServices.DataTransferObjects.Responses;
+using Microsoft.Extensions.Options;
 
 namespace DesolaServices.Services;
 
 public class AirlineRouteService : IAirlineRouteService
 {
-    private readonly IConfiguration _configuration;
+    private readonly AppSettings _configuration;
     private readonly IApiService _apiService;
     private readonly IAirlineRepository _airlineRepository;
     private readonly IMapper _mapper;
 
-    public AirlineRouteService(IConfiguration configuration, IApiService apiService, IAirlineRepository airlineRepository, IMapper mapper)
+    public AirlineRouteService(IOptions<AppSettings> configuration, IApiService apiService, IAirlineRepository airlineRepository, IMapper mapper)
     {
-        _configuration = configuration;
+        _configuration = configuration.Value;
         _apiService = apiService;
         _airlineRepository = airlineRepository;
         _mapper = mapper;
@@ -62,7 +63,7 @@ public class AirlineRouteService : IAirlineRouteService
 
     private Uri BuildSearchUri(string airlineCode, string arrivalCountryCode, int max = 100)
     {
-        var builder = new UriBuilder(_configuration["AmadeusApi_BaseUrl"] + "/v1/airline/destinations");
+        var builder = new UriBuilder(_configuration.ExternalApi.Amadeus.BaseUrl + "/v1/airline/destinations");
         var query = HttpUtility.ParseQueryString(string.Empty);
 
         query[nameof(airlineCode)] = airlineCode;


### PR DESCRIPTION
Introduced a new `AppSettings` class to centralize application configuration, replacing direct access to `IConfiguration`. Updated constructors in `Airports`, `AirlineRepository`, `ApiService`, `AirlineRouteService`, and `AirportScannerService` to use `IOptions<AppSettings>`. Modified `Program.cs` to configure services with `AppSettings` from `local.settings.json`. Enhanced type safety and maintainability across the codebase by leveraging the options pattern in .NET.